### PR TITLE
Fix the mysql login configuration file cannot be located in a cronjob

### DIFF
--- a/automysqlbackup
+++ b/automysqlbackup
@@ -84,6 +84,7 @@ load_default_config() {
   CONFIG_mysql_dump_dbstatus='yes'
   CONFIG_mysql_dump_differential='no'
   CONFIG_mysql_dump_login_path='automysqldump'
+  CONFIG_mysql_dump_login_path_file=''
   CONFIG_mysql_dump_encrypted_login='no'
   CONFIG_backup_local_files=()
   CONFIG_db_names=()
@@ -106,6 +107,9 @@ mysql_commands() {
     export MYSQLDUMP="mysqldump --login-path=$CONFIG_mysql_dump_login_path"
     export MYSQLSHOW="mysqlshow --login-path=$CONFIG_mysql_dump_login_path"
     export MYSQL="mysql --login-path=$CONFIG_mysql_dump_login_path"
+    if [ -n "${CONFIG_mysql_dump_login_path_file}" ]; then
+      export MYSQL_TEST_LOGIN_FILE=$CONFIG_mysql_dump_login_path_file
+    fi
   else
     export MYSQLDUMP="mysqldump --user=${CONFIG_mysql_dump_username} --password=${CONFIG_mysql_dump_password} --host=${CONFIG_mysql_dump_host}";
     export MYSQLSHOW="mysqlshow --user=${CONFIG_mysql_dump_username} --password=${CONFIG_mysql_dump_password} --host=${CONFIG_mysql_dump_host}";

--- a/automysqlbackup.conf
+++ b/automysqlbackup.conf
@@ -25,6 +25,11 @@
 # automysqldump is using the login-path "automysqldump" as default
 #CONFIG_mysql_dump_login_path='automysqldump'
 
+# Path to the mysql login configuration file.
+# Sometimes if the script is running in a cronjob, the mysql login configuration file cannot be located. 
+# I.e. set it to '/root/.mylogin.cnf' or '/home/username/.mylogin.cnf'
+#CONFIG_mysql_dump_login_path_file=''
+
 # Username to access the MySQL server e.g. dbuser
 #CONFIG_mysql_dump_username='root'
 


### PR DESCRIPTION
Fix for mysqldump to use the credentials from mysql_config_editor in a crontab-executed script in a ubuntu environment.

Details see:
https://askubuntu.com/questions/403588/how-can-i-get-mysqldump-to-use-the-credentials-from-mysql-config-editor-in-a-cro