### PR TITLE
Allow specifying database patterns for exclusion

### DIFF
--- a/automysqlbackup
+++ b/automysqlbackup
@@ -90,6 +90,7 @@ load_default_config() {
   CONFIG_db_names=()
   CONFIG_db_month_names=()
   CONFIG_db_exclude=( 'information_schema' )
+  CONFIG_db_exclude_pattern=()
   CONFIG_table_exclude=()
   CONFIG_mailcontent='stdout'
   CONFIG_mail_maxattsize=4000
@@ -1106,6 +1107,11 @@ parse_databases() {
 	for i in "${!alldbnames[@]}"; do if [[ "x${alldbnames[$i]}" = "x${exclude}" ]]; then unset 'alldbnames[i]'; fi; done
   done
   # <- remove excluded dbs from list
+
+  # -> remove excluded patterns from list
+  for pattern in "${CONFIG_db_exclude_pattern[@]}"; do
+    for i in "${!alldbnames[@]}"; do if [[ "x${alldbnames[$i]/${pattern}/}" != "x${alldbnames[$i]}" ]]; then unset 'alldbnames[i]'; fi; done
+  done
 
   # check for empty array lists and copy all dbs
   ((! ${#CONFIG_db_names[@]}))	&& CONFIG_db_names=( "${alldbnames[@]}" )

--- a/automysqlbackup.conf
+++ b/automysqlbackup.conf
@@ -79,6 +79,9 @@ CONFIG_backup_dir='/var/backup/db'
 # List of DBNAMES to EXLUCDE if DBNAMES is empty, i.e. ().
 CONFIG_db_exclude=( 'performance_schema' 'information_schema' )
 
+# List of DBNAMES patterns to EXLUCDE if DBNAMES is empty, i.e. ().
+CONFIG_db_exclude_pattern=()
+
 # List of tables to exclude, in the form db_name.table_name
 # You may use wildcards for the table names, i.e. 'mydb.a*' selects all tables starting with an 'a'.
 # However we only offer the wildcard '*', matching everything that could appear, which translates to the


### PR DESCRIPTION
Follows the process for excluding filenames. Uses bash pattern matching, not regex.