### PR TITLE
add --hex-blob option

### DIFF
--- a/automysqlbackup
+++ b/automysqlbackup
@@ -86,6 +86,7 @@ load_default_config() {
   CONFIG_mysql_dump_use_separate_dirs='yes'
   CONFIG_mysql_dump_compression='gzip'
   CONFIG_mysql_dump_commcomp='no'
+  CONFIG_mysql_dump_hex_blob='no'
   CONFIG_mysql_dump_latest='no'
   CONFIG_mysql_dump_latest_clean_filenames='no'
   CONFIG_mysql_dump_max_allowed_packet=''
@@ -531,6 +532,10 @@ parse_configuration () {
     [[ "${CONFIG_mysql_dump_max_allowed_packet}" ]]		&& {
 	  opt=( "${opt[@]}" "--max_allowed_packet=${CONFIG_mysql_dump_max_allowed_packet}" )
 	  opt_fullschema=( "${opt_fullschema[@]}" "--max_allowed_packet=${CONFIG_mysql_dump_max_allowed_packet}" )
+    }
+    [[ "${CONFIG_mysql_dump_hex_blob}" = "yes" ]]		&& {
+	  opt=( "${opt[@]}" '--hex-blob' )
+	  opt_fullschema=( "${opt_fullschema[@]}" '--hex-blob' )
     }
     [[ "${CONFIG_mysql_dump_socket}" ]]			&& {
 	  opt=( "${opt[@]}" "--socket=${CONFIG_mysql_dump_socket}" )

--- a/automysqlbackup.conf
+++ b/automysqlbackup.conf
@@ -204,6 +204,9 @@ CONFIG_db_exclude_pattern=()
 # Choose Compression type. (gzip, bzip2 or xz)
 #CONFIG_mysql_dump_compression='gzip'
 
+# Use hex-blob for backup?
+#CONFIG_mysql_dump_hex_blob='no'
+
 # Store an additional copy of the latest backup to a standard
 # location so it can be downloaded by third party scripts.
 #CONFIG_mysql_dump_latest='no'


### PR DESCRIPTION
This change adds an option to enable --hex-blob on database dumps.

https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_hex-blob

> Dump binary columns using hexadecimal notation (for example, 'abc' becomes 0x616263). The affected data types are BINARY, VARBINARY, BLOB types, BIT, all spatial data types, and other non-binary data types when used with the binary character set. 

https://stackoverflow.com/questions/16559086/does-mysqldump-handle-binary-data-reliably

> To avoid problems with encodings, binary transfers, etc, use the --hex-blob option, so it translates each byte in a hex number (for example, 'abc' becomes 0x616263). It will make the dump bigger, but it will be the most compatible and secure way to have the info (since it will be pure text, no weird misinterpretations due to special symbols generated with the binary data on a text file).