### PR TITLE
Added CONFIG_mysql_dump_tablespaces option to handle breaking change in MySQL 5.7.31 and 8.0.21

### DIFF
--- a/automysqlbackup
+++ b/automysqlbackup
@@ -93,6 +93,7 @@ load_default_config() {
   CONFIG_mysql_dump_master_data=
   CONFIG_mysql_dump_full_schema='yes'
   CONFIG_mysql_dump_dbstatus='yes'
+  CONFIG_mysql_dump_tablespaces='yes'
   CONFIG_mysql_dump_differential='no'
   CONFIG_mysql_dump_login_path='automysqldump'
   CONFIG_mysql_dump_login_path_file=''
@@ -558,6 +559,10 @@ parse_configuration () {
 
     if [[ "${CONFIG_mysql_dump_add_drop_database}" = "yes" ]]; then
       opt=( "${opt[@]}" '--add-drop-database' )
+    fi
+
+    if [[ "${CONFIG_mysql_dump_tablespaces}" = "no" ]]; then
+      opt=( "${opt[@]}" '--no-tablespaces' )
     fi
 
 	# if differential backup is active and the specified rotation is smaller than 21 days, set it to 21 days to ensure, that

--- a/automysqlbackup.conf
+++ b/automysqlbackup.conf
@@ -190,6 +190,11 @@ CONFIG_db_exclude_pattern=()
 # in the meantime.
 #CONFIG_mysql_dump_dbstatus='yes'
 
+# Include tablespace information in backup?
+# As a breaking change in MySQL 5.7.31 and 8.0.21, mysqldump requires either
+# PROCESS privileges or must be invoked with the --no-tablespaces option.
+#CONFIG_mysql_dump_tablespaces='yes'
+
 # Backup dump settings
 
 # Include CREATE DATABASE in backup?


### PR DESCRIPTION
Added CONFIG_mysql_dump_tablespaces (default 'yes'). When set to 'no' it adds the option `--no-tablespaces` to the invocation of mysqldump. The default behaviour remains unchanged.

As a breaking change in MySQL [5.7.31](https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-31.html#mysqld-5-7-31-security) and [8.0.21](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-21.html#mysqld-8-0-21-security), mysqldump now requires the PROCESS privilege to access tablespace information. If no tablespace information is needed, `--no-tablespaces` can be added to the mysqldump invocation to lower the privileges required by the mysqldump user.