### PR TITLE
Added CONFIG_mysql_dump_create_event to allow backups with fewer privileges if events are not used

### DIFF
--- a/automysqlbackup
+++ b/automysqlbackup
@@ -83,6 +83,7 @@ load_default_config() {
   CONFIG_mysql_dump_socket=''
   CONFIG_mysql_dump_create_database='no'
   CONFIG_mysql_dump_add_drop_database='no'
+  CONFIG_mysql_dump_create_event='yes'
   CONFIG_mysql_dump_use_separate_dirs='yes'
   CONFIG_mysql_dump_compression='gzip'
   CONFIG_mysql_dump_commcomp='no'
@@ -492,7 +493,7 @@ backup_local_files () {
 # @deps:	load_default_config
 parse_configuration () {
     # OPT string for use with mysqldump ( see man mysqldump )
-    opt=( '--quote-names' '--opt' '--events' )
+    opt=( '--quote-names' '--opt' )
 
     # OPT string for use with mysql (see man mysql )
     mysql_opt=()
@@ -558,6 +559,10 @@ parse_configuration () {
 
     if [[ "${CONFIG_mysql_dump_add_drop_database}" = "yes" ]]; then
       opt=( "${opt[@]}" '--add-drop-database' )
+    fi
+
+    if [[ "${CONFIG_mysql_dump_create_event}" = "yes" ]]; then
+      opt=( "${opt[@]}" '--events' )
     fi
 
 	# if differential backup is active and the specified rotation is smaller than 21 days, set it to 21 days to ensure, that

--- a/automysqlbackup.conf
+++ b/automysqlbackup.conf
@@ -192,6 +192,9 @@ CONFIG_db_exclude_pattern=()
 
 # Backup dump settings
 
+# Include CREATE EVENT in backup?
+#CONFIG_mysql_dump_create_event='yes'
+
 # Include CREATE DATABASE in backup?
 #CONFIG_mysql_dump_create_database='no'
 


### PR DESCRIPTION
Added CONFIG_mysql_dump_create_event (default 'yes') which toggles mysqldump option `--events`. The default behavior is unchanged.

This option allow users that do not use events (or do not wish to back them up) to backup their database without the EVENT privilege. Combined with https://github.com/sixhop/AutoMySQLBackup/pull/51 it allows for backups using only SELECT (and LOCK TABLES if CONFIG_mysql_dump_single_transaction is 'yes') and RELOAD privileges.