### PR TITLE
Removing mysql* warning during usage of --password

### DIFF
--- a/automysqlbackup
+++ b/automysqlbackup
@@ -126,9 +126,10 @@ mysql_commands() {
       export MYSQL_TEST_LOGIN_FILE=$CONFIG_mysql_dump_login_path_file
     fi
   else
-    export MYSQLDUMP="mysqldump --user=${CONFIG_mysql_dump_username} --password=${CONFIG_mysql_dump_password} --host=${CONFIG_mysql_dump_host}";
-    export MYSQLSHOW="mysqlshow --user=${CONFIG_mysql_dump_username} --password=${CONFIG_mysql_dump_password} --host=${CONFIG_mysql_dump_host}";
-    export MYSQL="mysql --user=${CONFIG_mysql_dump_username} --password=${CONFIG_mysql_dump_password} --host=${CONFIG_mysql_dump_host}";
+    export MYSQL_PWD=${CONFIG_mysql_dump_password}
+    export MYSQLDUMP="mysqldump --user=${CONFIG_mysql_dump_username} --host=${CONFIG_mysql_dump_host}";
+    export MYSQLSHOW="mysqlshow --user=${CONFIG_mysql_dump_username} --host=${CONFIG_mysql_dump_host}";
+    export MYSQL="mysql --user=${CONFIG_mysql_dump_username} --host=${CONFIG_mysql_dump_host}";
   fi
 }
 


### PR DESCRIPTION
Using a password on the command line interface can be insecure.